### PR TITLE
feat: implement priority labels for notes

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -9,7 +9,8 @@
       "Bash(crystal tool format:*)",
       "Bash(crystal spec)",
       "Bash(ameba:*)",
-      "Bash(git add:*)"
+      "Bash(git add:*)",
+      "Bash(git reset:*)"
     ],
     "deny": [],
     "ask": []

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,17 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(find:*)",
+      "Bash(git checkout:*)",
+      "Bash(shards build:*)",
+      "WebFetch(domain:github.com)",
+      "Bash(ameba)",
+      "Bash(crystal tool format:*)",
+      "Bash(crystal spec)",
+      "Bash(ameba:*)",
+      "Bash(git add:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ integration-test/node_modules
 integration-test/test-results/
 integration-test/testdata/
 .last-run.json
+tocry

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,120 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build and Development Commands
+
+### Building
+```bash
+# Development mode
+crystal run src/main.cr
+
+# Production build (static binary)
+shards build --release --progress
+
+# Docker build (multi-arch)
+docker buildx build --platform linux/amd64,linux/arm64 -t tocry .
+```
+
+### Testing
+```bash
+# Run unit tests
+crystal spec
+# or use convenience script
+./run_unit.sh
+
+# Run integration tests (requires Playwright)
+cd integration-test && npm test
+```
+
+### Linting and Code Quality
+```bash
+# Lint code
+ameba
+
+# Auto-fix linting issues
+ameba --fix
+```
+
+## Architecture Overview
+
+ToCry is a Kanban-style TODO application built in Crystal using the Kemal web framework. It's designed as a single-binary, self-hosted application with file-based persistence.
+
+### Core Architecture
+
+1. **Multi-board System**: Users can have multiple Kanban boards, each containing lanes and notes
+2. **File-based Storage**: Uses JSON files for persistence (no database required)
+3. **User Isolation**: Each user gets their own data directory for multi-tenant support
+4. **Static Asset Bundling**: All CSS, JS, and assets are compiled into the binary using BakedFileSystem
+
+### Key Components
+
+- **src/tocry.cr**: Main application module and configuration
+- **src/main.cr**: Application entry point and server setup
+- **src/board_manager.cr**: Handles multi-board management and persistence
+- **src/endpoints/**: RESTful API endpoints (boards, lanes, notes, uploads, auth)
+- **src/assets/**: Frontend JavaScript and CSS
+- **templates/**: ECR templates for server-side rendering
+
+### Authentication Modes
+
+The application supports three authentication modes (controlled by environment variables):
+
+1. **Google OAuth** (priority 1): Requires `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`
+2. **Basic Auth** (priority 2): Requires `AUTH_USER` and `AUTH_PASSWORD`
+3. **No Authentication** (default): Open access
+
+### Data Structure
+
+```
+data/
+├── {user_id}/          # User-specific directory
+│   ├── boards/         # Individual board JSON files
+│   └── settings.json   # User preferences
+└── global/             # Shared data (if any)
+```
+
+## Development Notes
+
+### Code Style and Conventions
+
+- The codebase follows Crystal naming conventions
+- Use docopt for command-line interfaces (per user preference)
+- Avoid `not_nil!` and excessive `.to_s` calls
+- Use descriptive parameter names in blocks
+- Follow existing patterns for API endpoints
+
+### Testing Strategy
+
+- Unit tests in `spec/` use Crystal's built-in testing framework
+- Integration tests in `integration-test/` use Playwright for E2E testing
+- Test coverage includes core domain models (Board, Lane, Note, BoardManager)
+
+### Frontend Architecture
+
+- Single-page application with server-side rendering
+- Vanilla JavaScript (no frameworks)
+- Pico.css for styling
+- Drag-and-drop functionality using HTML5 drag API
+- WebSocket support for real-time updates (when available)
+
+### Migration System
+
+- Data migrations are stored in `src/migrations/`
+- Migrations run automatically on startup if needed
+- Versioning ensures backward compatibility
+
+### Docker Deployment
+
+- Multi-architecture support (AMD64, ARM64)
+- Static binary compilation
+- Volume mounting for data persistence at `/data`
+- Environment variable configuration for auth and settings
+
+### Common Pitfalls
+
+- Always validate file paths to prevent directory traversal
+- Use `File.expand_path` for path joining operations
+- Check file existence before operations
+- Handle user authentication in the correct order (Google OAuth → Basic Auth → None)
+- Remember to run migrations after schema changes

--- a/src/assets/api.js
+++ b/src/assets/api.js
@@ -103,7 +103,7 @@ export async function updateLane (boardName, oldName, laneData, position) {
   return response
 }
 
-export async function addNote (boardName, laneName, title, content = '', tags = [], startDate = null, endDate = null) {
+export async function addNote (boardName, laneName, title, content = '', tags = [], startDate = null, endDate = null, priority = null) {
   // The boardName parameter is passed explicitly from the caller (e.g., note.js)
   const response = await fetch(`${API_BASE_URL}/boards/${boardName}/note`, {
     method: 'POST',
@@ -117,7 +117,8 @@ export async function addNote (boardName, laneName, title, content = '', tags = 
         content,
         tags,
         start_date: startDate,
-        end_date: endDate
+        end_date: endDate,
+        priority
       } // id is omitted, backend generates it
     })
   })

--- a/src/assets/features/note-crud.js
+++ b/src/assets/features/note-crud.js
@@ -51,7 +51,8 @@ export async function handleAddNoteRequest (laneName) {
         '',
         [],
         null, // start_date
-        null // end_date
+        null, // end_date
+        null // priority
       )
       if (response.ok) {
         showNotification(`Note "${noteTitle}" added successfully to lane "${laneName}".`, 'success')

--- a/src/assets/features/note-modals.js
+++ b/src/assets/features/note-modals.js
@@ -27,6 +27,7 @@ export function handleEditNoteRequest (note) {
   document.getElementById('edit-note-public').checked = note.public
   document.getElementById('edit-note-start-date').value = note.start_date || ''
   document.getElementById('edit-note-end-date').value = note.end_date || ''
+  document.getElementById('edit-note-priority').value = note.priority || 'medium'
 
   const contentTextarea = document.getElementById('edit-note-content')
   toastuiEditor = new toastui.Editor({
@@ -109,7 +110,8 @@ export async function handleEditNoteSubmit (event) {
     content: toastuiEditor.getMarkdown(),
     public: document.getElementById('edit-note-public').checked,
     start_date: document.getElementById('edit-note-start-date').value || null,
-    end_date: document.getElementById('edit-note-end-date').value || null
+    end_date: document.getElementById('edit-note-end-date').value || null,
+    priority: document.getElementById('edit-note-priority').value
   }
 
   let noteInCache = null

--- a/src/assets/render.js
+++ b/src/assets/render.js
@@ -210,27 +210,23 @@ export function createNoteCardElement (note, laneName, callbacks, dragAndDropCal
 
   summaryDiv.appendChild(headerRow)
 
-  // Add priority tab - only show if priority is set
+  // Add priority bookmark - only show if priority is set
   if (note.priority) {
-    let priorityEmoji = ''
     let priorityClass = ''
 
     switch (note.priority) {
       case 'high':
-        priorityEmoji = '🔴'
         priorityClass = 'priority-high-tab'
         break
       case 'medium':
-        priorityEmoji = '🟠'
         priorityClass = 'priority-medium-tab'
         break
       case 'low':
-        priorityEmoji = '🟢'
         priorityClass = 'priority-low-tab'
         break
     }
 
-    const priorityTab = createElement('div', `priority-tab ${priorityClass}`, priorityEmoji)
+    const priorityTab = createElement('div', `priority-tab ${priorityClass}`, '')
     priorityTab.title = `${note.priority.charAt(0).toUpperCase() + note.priority.slice(1)} Priority`
     noteCard.appendChild(priorityTab)
   }

--- a/src/assets/render.js
+++ b/src/assets/render.js
@@ -210,6 +210,31 @@ export function createNoteCardElement (note, laneName, callbacks, dragAndDropCal
 
   summaryDiv.appendChild(headerRow)
 
+  // Add priority tab - only show if priority is set
+  if (note.priority) {
+    let priorityEmoji = ''
+    let priorityClass = ''
+
+    switch (note.priority) {
+      case 'high':
+        priorityEmoji = '🔴'
+        priorityClass = 'priority-high-tab'
+        break
+      case 'medium':
+        priorityEmoji = '🟠'
+        priorityClass = 'priority-medium-tab'
+        break
+      case 'low':
+        priorityEmoji = '🟢'
+        priorityClass = 'priority-low-tab'
+        break
+    }
+
+    const priorityTab = createElement('div', `priority-tab ${priorityClass}`, priorityEmoji)
+    priorityTab.title = `${note.priority.charAt(0).toUpperCase() + note.priority.slice(1)} Priority`
+    noteCard.appendChild(priorityTab)
+  }
+
   // Add dates inside the summary but as a separate element
   if (datesContainer) {
     summaryDiv.appendChild(datesContainer)

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -771,73 +771,76 @@ body {
     border-color: rgba(34, 197, 94, 0.3);
 }
 
-/* Priority tabs on the right side of notes */
+/* Priority bookmark on the right side of notes */
 .priority-tab {
     position: absolute;
-    top: 5px;
-    right: 0;
-    width: 20px;
-    height: 25px;
+    top: -8px;
+    right: 8px;
+    width: 18px;
+    height: 30px;
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 0.8em;
+    font-size: 0.75em;
     cursor: pointer;
-    border-radius: 3px 0 0 3px;
     z-index: 1;
+    clip-path: polygon(0 0, 100% 0, 100% 75%, 50% 100%, 0 75%);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
 }
 
 .priority-high-tab {
-    background-color: rgb(185, 28, 28); /* red-700 */
+    background-color: rgb(190, 30, 45); /* muted red */
     color: white;
 }
 
 .priority-medium-tab {
-    background-color: rgb(194, 65, 12); /* orange-700 */
+    background-color: rgb(180, 100, 50); /* muted orange/brown */
     color: white;
 }
 
 .priority-low-tab {
-    background-color: rgb(21, 128, 61); /* green-700 */
+    background-color: rgb(80, 140, 70); /* muted green */
     color: white;
 }
 
-/* Priority input in edit modal */
-.priority-input {
-    margin: 1rem 0;
+/* Date and priority inputs in edit modal */
+.date-priority-inputs {
+    display: flex;
+    gap: 0.5rem;
+    margin: 0.5rem 0;
 }
 
-.priority-input label {
-    display: block;
+#edit-note-tags {
+    margin-bottom: 0;
+}
+
+#edit-note-title {
     margin-bottom: 0.5rem;
-    font-weight: 600;
 }
 
-.priority-input select {
-    width: 100%;
+.date-priority-inputs input[type="date"] {
+    flex: 1;
     padding: 0.5rem;
-    border-radius: var(--pico-border-radius);
     border: 1px solid var(--pico-form-element-border-color);
+    border-radius: var(--pico-border-radius);
     background-color: var(--pico-background-color);
     color: var(--pico-color);
     font-size: 1rem;
 }
 
-.priority-input select:focus {
+.date-priority-inputs select {
+    flex: 1;
+    padding: 0.5rem;
+    border: 1px solid var(--pico-form-element-border-color);
+    border-radius: var(--pico-border-radius);
+    background-color: var(--pico-background-color);
+    color: var(--pico-color);
+    font-size: 0.9rem;
+}
+
+.date-priority-inputs select:focus {
     outline: 2px solid var(--pico-primary);
     outline-offset: 2px;
-}
-
-/* Date inputs container in edit modal */
-.date-inputs {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 1rem;
-    margin-bottom: 1rem;
-}
-
-.date-inputs input[type="date"] {
-    width: 100%;
 }
 
 .note-tags .tag {

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -562,6 +562,7 @@ body {
     /* Add padding to create vertical space between note cards */
     padding: 10px 0;
     cursor: grab;
+    position: relative; /* For positioning priority tab */
     /* --- New styles for search animation --- */
     transition: all 0.35s ease-in-out, box-shadow 0.2s ease-in-out;
     box-shadow: 0 2px 5px var(--tocry-note-shadow); /* Subtle shadow for normal state */
@@ -733,6 +734,98 @@ body {
     border: 1px solid var(--pico-form-element-border-color);
     width: 100%;
     box-sizing: border-box;
+}
+
+/* Priority badge styling */
+.note-priority {
+    margin: 0 0.5rem;
+}
+
+.priority-badge {
+    font-size: 0.8em;
+    font-weight: 600;
+    padding: 0.2rem 0.5rem;
+    border-radius: var(--pico-border-radius);
+    display: inline-block;
+    width: 100%;
+    box-sizing: border-box;
+    text-align: center;
+    border: 1px solid transparent;
+}
+
+.priority-high {
+    background-color: rgba(239, 68, 68, 0.1); /* red-500 with opacity */
+    color: rgb(185, 28, 28); /* red-700 */
+    border-color: rgba(239, 68, 68, 0.3);
+}
+
+.priority-medium {
+    background-color: rgba(251, 146, 60, 0.1); /* orange-500 with opacity */
+    color: rgb(194, 65, 12); /* orange-700 */
+    border-color: rgba(251, 146, 60, 0.3);
+}
+
+.priority-low {
+    background-color: rgba(34, 197, 94, 0.1); /* green-500 with opacity */
+    color: rgb(21, 128, 61); /* green-700 */
+    border-color: rgba(34, 197, 94, 0.3);
+}
+
+/* Priority tabs on the right side of notes */
+.priority-tab {
+    position: absolute;
+    top: 5px;
+    right: 0;
+    width: 20px;
+    height: 25px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.8em;
+    cursor: pointer;
+    border-radius: 3px 0 0 3px;
+    z-index: 1;
+}
+
+.priority-high-tab {
+    background-color: rgb(185, 28, 28); /* red-700 */
+    color: white;
+}
+
+.priority-medium-tab {
+    background-color: rgb(194, 65, 12); /* orange-700 */
+    color: white;
+}
+
+.priority-low-tab {
+    background-color: rgb(21, 128, 61); /* green-700 */
+    color: white;
+}
+
+/* Priority input in edit modal */
+.priority-input {
+    margin: 1rem 0;
+}
+
+.priority-input label {
+    display: block;
+    margin-bottom: 0.5rem;
+    font-weight: 600;
+}
+
+.priority-input select {
+    width: 100%;
+    padding: 0.5rem;
+    border-radius: var(--pico-border-radius);
+    border: 1px solid var(--pico-form-element-border-color);
+    background-color: var(--pico-background-color);
+    color: var(--pico-color);
+    font-size: 1rem;
+}
+
+.priority-input select:focus {
+    outline: 2px solid var(--pico-primary);
+    outline-offset: 2px;
 }
 
 /* Date inputs container in edit modal */

--- a/src/endpoints/helpers.cr
+++ b/src/endpoints/helpers.cr
@@ -112,15 +112,30 @@ module ToCry::Endpoints::Helpers
 
   struct UpdateNotePayload
     include JSON::Serializable
-    property note : ToCry::Note
+    property note : NoteData
     property lane_name : String?
     property position : UInt64?
   end
 
   struct NewNotePayload
     include JSON::Serializable
-    property note : ToCry::Note # The note data (id will be ignored/overwritten as a new one is generated)
+    property note : NoteData # The note data (id will be ignored/overwritten as a new one is generated)
     property lane_name : String
+  end
+
+  struct NoteData
+    include JSON::Serializable
+    property title : String
+    property tags : Array(String) = [] of String
+    property content : String = ""
+    # ameba:disable Naming/QueryBoolMethods
+    property expanded : Bool = false
+    # ameba:disable Naming/QueryBoolMethods
+    property public : Bool = false
+    property attachments : Array(String) = [] of String
+    property start_date : String? = nil
+    property end_date : String? = nil
+    property priority : String? = nil
   end
 
   struct ShareBoardPayload

--- a/src/lane.cr
+++ b/src/lane.cr
@@ -31,8 +31,8 @@ module ToCry
       @sepia_id = @name = "Untitled Lane" # Default name if not provided
     end
 
-    def note_add(title : String, tags : Array(String) = [] of String, content : String = "", position : Int = 0, public : Bool = false, start_date : String? = nil, end_date : String? = nil) : Note
-      new_note = Note.new(title: title, tags: tags, content: content, public: public, start_date: start_date, end_date: end_date)
+    def note_add(title : String, tags : Array(String) = [] of String, content : String = "", position : Int = 0, public : Bool = false, start_date : String? = nil, end_date : String? = nil, priority : Priority? = nil) : Note
+      new_note = Note.new(title: title, tags: tags, content: content, public: public, start_date: start_date, end_date: end_date, priority: priority)
       actual_position = position.clamp(0, self.notes.size)
 
       self.notes.insert(actual_position, new_note)

--- a/templates/app.ecr
+++ b/templates/app.ecr
@@ -112,17 +112,14 @@
 
           <input type="text" id="edit-note-tags" name="tags" placeholder="Tags (comma-separated)" />
 
-          <div class="date-inputs">
-            <input type="date" id="edit-note-start-date" name="start_date" placeholder="Start date (YYYY-MM-DD)" />
-            <input type="date" id="edit-note-end-date" name="end_date" placeholder="End date (YYYY-MM-DD)" />
-          </div>
-          <div class="priority-input">
-            <label for="edit-note-priority">Priority:</label>
+          <div class="date-priority-inputs">
+            <input type="date" id="edit-note-start-date" name="start_date" placeholder="Start date" />
+            <input type="date" id="edit-note-end-date" name="end_date" placeholder="End date" />
             <select id="edit-note-priority" name="priority">
-              <option value="">None</option>
-              <option value="high">🔴 High</option>
-              <option value="medium">🟠 Medium</option>
-              <option value="low">🟢 Low</option>
+              <option value="">Priority</option>
+              <option value="high">High Priority</option>
+              <option value="medium">Medium Priority</option>
+              <option value="low">Low Priority</option>
             </select>
           </div>
           <!-- Toast UI Editor needs a div to render into, not a textarea -->

--- a/templates/app.ecr
+++ b/templates/app.ecr
@@ -116,6 +116,15 @@
             <input type="date" id="edit-note-start-date" name="start_date" placeholder="Start date (YYYY-MM-DD)" />
             <input type="date" id="edit-note-end-date" name="end_date" placeholder="End date (YYYY-MM-DD)" />
           </div>
+          <div class="priority-input">
+            <label for="edit-note-priority">Priority:</label>
+            <select id="edit-note-priority" name="priority">
+              <option value="">None</option>
+              <option value="high">🔴 High</option>
+              <option value="medium">🟠 Medium</option>
+              <option value="low">🟢 Low</option>
+            </select>
+          </div>
           <!-- Toast UI Editor needs a div to render into, not a textarea -->
           <div id="edit-note-content"></div>
         </form>


### PR DESCRIPTION
## Summary
- Add Priority enum with High, Medium, Low values for type safety
- Implement priority as colored bookmark peeking from right side of notes
- Add "None" priority option in edit modal dropdown
- Update frontend to only show priority bookmark when priority is set
- Refactor backend to use enum instead of string validation
- Add proper JSON/YAML serialization for Priority enum
- Create NoteData payload struct for API requests
- Update all endpoints to handle priority enum conversion
- Improve modal layout by moving priority select next to date inputs
- Use muted colors for a more professional appearance

## Test plan
- Create a new note and verify priority can be set to None/High/Medium/Low
- Edit existing notes and change their priority
- Verify priority bookmarks appear only when priority is set
- Verify bookmark colors correspond to priority level (red=high, orange=medium, green=low)
- Check that modal layout shows priority dropdown next to date inputs
- Test drag and drop still works properly
- Verify all existing functionality remains intact

🤖 Generated with LGM 4.5 from z.ai